### PR TITLE
Initial work on namespaced names

### DIFF
--- a/spec/lib/smart_name_spec.rb
+++ b/spec/lib/smart_name_spec.rb
@@ -2,8 +2,16 @@
 require File.expand_path('../spec_helper', File.dirname(__FILE__))
 require 'core_ext'
 
-
 describe SmartName do
+  before :all do
+    SmartName.class_eval do
+      def self.load_namespaces
+        {'root_namespace' => 'RootNamespace',
+         'root_namespace+path_element+sub_namespace' => 'RootNamespace+PathElement+SubNamespace'
+        }
+      end
+    end
+  end
 
   describe "#key" do
     it "should remove spaces" do
@@ -238,4 +246,22 @@ describe SmartName do
     end
   end
 
+  describe "namespaced namse" do
+    let(:root_part) { 'RootNamespace' }
+    let(:plus_a) { root_part + '+A' }
+    let(:subspace) { 'PathElement+SubNamespace' }
+    let(:plus_sub) { "#{root_part}+#{subspace}" }
+    let(:plus_bc)  { plus_sub + '+B+C' }
+
+    it 'works in namespaces' do
+      root_part.to_name.rootspace.should be_true
+      plus_a.to_name.rootspace.should be_false
+      plus_sub.to_name.rootspace.should be_false
+      root_part.to_name.namespaced.should == [root_part]
+      plus_a.to_name.namespaced.should == [root_part, 'A']
+      plus_sub.to_name.namespaced.should == [root_part, subspace]
+      plus_bc.to_name.namespaced.should == [root_part, subspace, 'B+C']
+      plus_bc.to_name.to_s.should == plus_bc
+    end
+  end
 end


### PR DESCRIPTION
The initial idea of having the name parser find the namespaced segments of a name seems to be fairly simple.  On the other hand, it raises a lot of questions we never addressed to deeply.  In current use, names that start with a joint character (+ by default) are considered relative and need to be interpreted in the context of another card to get an absolute name.  The begs the question because namespacing really only applies to absolute names.

The to_absolute(context) call is designed for that and it can also interpret a number of other contextual references.  Now, this contextual processing needs some overhaul.  A thought was that in transitioning from + to / for the default joint we could add some name semantics.  Using the conventions more typical of paths, absolute names would be marked, and then /Name can be relative to the namespace of the context name, //Name would be absolute (relative to the root namespace) and in web contexts /// could be from the server root.

We also need to think about what API we will want for this.  Should some of the current methods apply to the local name (i.e. the last element of name.namespaced), or always to the full name.  What about simple?, etc.