### PR TITLE
handle unstable uninflections

### DIFF
--- a/lib/smart_name.rb
+++ b/lib/smart_name.rb
@@ -139,9 +139,6 @@ class SmartName < Object
     @decoded ||= s.index('&') ? HTMLEntities.new.decode(s) : s
   end
 
-  def uninflect name
-    self.class.uninflect
-  end
   # ~~~~~~~~~~~~~~~~~~~ PARTS ~~~~~~~~~~~~~~~~~~~
 
   alias simple? simple

--- a/lib/smart_name.rb
+++ b/lib/smart_name.rb
@@ -42,9 +42,9 @@ class SmartName < Object
     # eg. it fails with singularize as uninflect method for Matthias -> Matthia -> Matthium
     # Usually that means the name is a proper noun and not a plural.
     # You can choose between two solutions:
-    # 1. don't uninflect if the uninflected key is not stable (stabelize = false)
+    # 1. don't uninflect if the uninflected key is not stable (stabilize = false)
     #    (probably the best choice because you want Matthias not to be the same  as Matthium)
-    # 2. uninflect until the key is stable (stabelize = true)
+    # 2. uninflect until the key is stable (stabilize = true)
     def stable_uninflect name
       key_one = name.send(SmartName.uninflect)
       key_two = key_one.send(SmartName.uninflect)

--- a/lib/smart_name.rb
+++ b/lib/smart_name.rb
@@ -10,13 +10,13 @@ class SmartName < Object
 
   include ActiveSupport::Configurable
 
-  config_accessor :joint, :banned_array, :var_re, :uninflect, :params, :session, :stabelize
+  config_accessor :joint, :banned_array, :var_re, :uninflect, :params, :session, :stabilize
 
   SmartName.joint          = '+'
   SmartName.banned_array   = ['/', '~', '|']
   SmartName.var_re         = /\{([^\}]*\})\}/
   SmartName.uninflect      = :singularize
-  SmartName.stabelize      = false       
+  SmartName.stabilize      = false       
   
 
   JOINT_RE = Regexp.escape joint
@@ -49,7 +49,7 @@ class SmartName < Object
       key_one = name.send(SmartName.uninflect)
       key_two = key_one.send(SmartName.uninflect)
       return key_one unless key_one != key_two
-      stabelize ? stable_uninflect(key_two) : name
+      SmartName.stabilize ? stable_uninflect(key_two) : name
     end
   end
 

--- a/spec/lib/smart_name_spec.rb
+++ b/spec/lib/smart_name_spec.rb
@@ -62,6 +62,26 @@ describe SmartName do
       'Jean-fran&ccedil;ois Noubel'.to_name.key.should == 'jean_françoi_noubel'
     end
   end
+  
+  describe 'unstable keys' do
+    context 'stabilize' do
+      before do
+        SmartName.stabilize = true
+      end
+      it 'should uninflect until key is stable' do
+        "matthias".to_name.key.should == "matthium"
+      end
+    end
+    
+    context 'do not stabilize' do
+      before do
+        SmartName.stabilize = false
+      end
+      it 'should not uninflect unstable names' do
+        "ilias".to_name.key.should == "ilias"
+      end
+    end
+  end
 
   describe 'parts and pieces' do
     it 'should produce simple strings for parts' do


### PR DESCRIPTION
sometimes the core rule "the key's key must be itself" (called "stable" below) is violated
eg. it fails with singularize as uninflect method for Matthias -> Matthia -> Matthium
Usually that means the name is a proper noun and not a plural.
I implemented two solutions and you can choose one via config option SmartName.stabilize:
1. don't uninflect if the uninflected key is not stable (stabilize = false)
(probably the best choice because you want Matthias not to be the same  as Matthium)
2. uninflect until the key is stable (stabilize = true)